### PR TITLE
Add increased sticky forces and kickoff grounding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,7 +1070,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zero-g-script"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rlbot",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zero-g-script"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]

--- a/script.toml
+++ b/script.toml
@@ -2,13 +2,13 @@
 [settings]
 name = "Zero G"
 agent_id = "swz/zero-g-script"
-run_command = "target/release/zero-g-script.exe"
-run_command_linux = "target/release/zero-g-script"
+run_command = "cargo run"
+run_command_linux = "cargo run"
 logo_file = "./icon.svg"
 
 [details]
-# description = ""
-# fun_fact = ""
+description = "Sets gravity to 0 and increases sticky forces by 300 uu/s so walls are easily drivable."
+fun_fact = "In space, nobody can hear you scream"
 source_link = "https://github.com/swz-git/zero-g-script"
 developer = "swz"
 language = "rust"


### PR DESCRIPTION
An extra 300 uu/s seems to be the sweet spot where suspension no longer makes you airborne while making sharp turns on curved wall segments. It is also applied during kick off countdown so the cars start on the ground.